### PR TITLE
Fallback wasm to asm on iOS Safari due to instablity

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install [Docker](https://www.docker.com/) and run `build.sh` on Posix or `build.
 
 Copy `build/stbvorbis.js` to your file server and load it via a script tag.
 
-This library uses WebAssembly. If you want to use stbvorbis.js at browsers that do not support WebAssembly (e.g. iOS 9 Safari), copy `build/stbvorbis_asm.js` to the same directory as `build/stbvorbis.js` so that asm.js version is used as fallback.
+This library uses WebAssembly. But wasm on iOS Safari is STILL unstable even if it is iOS 13 :sob: , so we fallbacked it asm.js on iOS. So, if you want to use stbvorbis.js on iOS, copy `build/stbvorbis_asm.js` to the same directory as `build/stbvorbis.js` so that asm.js version is used as fallback.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install [Docker](https://www.docker.com/) and run `build.sh` on Posix or `build.
 
 Copy `build/stbvorbis.js` to your file server and load it via a script tag.
 
-This library basically uses WebAssembly. stbvorbis.js also has asm.js implementation for environments where WebAssembly is not available. On iOS, stbvorbis.js always uses asm.js instead due to instability of iOS WebAssembly implementation. Copy build/stbvorbis_asm.js to the same directory as build/stbvorbis.js so that asm.js version is used as fallback.
+This library basically uses WebAssembly. stbvorbis.js also has asm.js implementation for environments where WebAssembly is not available. On iOS, stbvorbis.js always uses asm.js instead due to instability of iOS WebAssembly implementation. Copy `build/stbvorbis_asm.js` to the same directory as `build/stbvorbis.js` so that asm.js version is used as fallback.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install [Docker](https://www.docker.com/) and run `build.sh` on Posix or `build.
 
 Copy `build/stbvorbis.js` to your file server and load it via a script tag.
 
-This library uses WebAssembly. But wasm on iOS Safari is STILL unstable even if it is iOS 13 :sob: , so we fallbacked it asm.js on iOS. So, if you want to use stbvorbis.js on iOS, copy `build/stbvorbis_asm.js` to the same directory as `build/stbvorbis.js` so that asm.js version is used as fallback.
+This library basically uses WebAssembly. stbvorbis.js also has asm.js implementation for environments where WebAssembly is not available. On iOS, stbvorbis.js always uses asm.js instead due to instability of iOS WebAssembly implementation. Copy build/stbvorbis_asm.js to the same directory as build/stbvorbis.js so that asm.js version is used as fallback.
 
 ## API
 

--- a/post.js
+++ b/post.js
@@ -40,7 +40,7 @@ function httpGet(url) {
 
 var initializeWorkerP = new Promise(function(resolve, reject) {
   // wasm on iOS Safari is STILL unstable even if it is iOS 13
-  var isiOS = navigator.userAgent.match(/iPhone|iPad|iPod/);
+  var isiOS = navigator.userAgent.match(/iPhone|iPad/);
   if (typeof WebAssembly === 'object' && !isiOS) {
     var workerURL = URL.createObjectURL(new Blob(
       ['(' + decodeWorker.toString() + ')();'],

--- a/post.js
+++ b/post.js
@@ -39,6 +39,7 @@ function httpGet(url) {
 }
 
 var initializeWorkerP = new Promise(function(resolve, reject) {
+  // wasm on iOS Safari is STILL unstable even if it is iOS 13
   var isiOSSafari = navigator.userAgent.match(/iPhone|iPad|iPod/) && navigator.userAgent.match(/AppleWebKit/);
   if (typeof WebAssembly === 'object' && !isiOSSafari) {
     var workerURL = URL.createObjectURL(new Blob(

--- a/post.js
+++ b/post.js
@@ -39,7 +39,8 @@ function httpGet(url) {
 }
 
 var initializeWorkerP = new Promise(function(resolve, reject) {
-  if (typeof WebAssembly === 'object') {
+  var isiOSSafari = navigator.userAgent.match(/iPhone|iPad|iPod/) && navigator.userAgent.match(/AppleWebKit/);
+  if (typeof WebAssembly === 'object' && !isiOSSafari) {
     var workerURL = URL.createObjectURL(new Blob(
       ['(' + decodeWorker.toString() + ')();'],
       {type: 'text/javascript'}

--- a/post.js
+++ b/post.js
@@ -40,8 +40,8 @@ function httpGet(url) {
 
 var initializeWorkerP = new Promise(function(resolve, reject) {
   // wasm on iOS Safari is STILL unstable even if it is iOS 13
-  var isiOSSafari = navigator.userAgent.match(/iPhone|iPad|iPod/) && navigator.userAgent.match(/AppleWebKit/);
-  if (typeof WebAssembly === 'object' && !isiOSSafari) {
+  var isiOS = navigator.userAgent.match(/iPhone|iPad|iPod/);
+  if (typeof WebAssembly === 'object' && !isiOS) {
     var workerURL = URL.createObjectURL(new Blob(
       ['(' + decodeWorker.toString() + ')();'],
       {type: 'text/javascript'}


### PR DESCRIPTION
wasm is unstable on iOS Safari whether it is 12, 13 or others 😭 